### PR TITLE
Use something more standard as the default viewport size

### DIFF
--- a/casper/jslib/djangocasper.js
+++ b/casper/jslib/djangocasper.js
@@ -29,6 +29,8 @@ module.exports = (function() {
         var start_url = base_url + arguments[0];
         var i;
 
+        casper.options.viewportSize = { width: 1024, height: 768 };
+
         if (first_scenario) {
             inject_cookies();
 


### PR DESCRIPTION
The casper viewport is 400x300 by default. This is kind of non-intuitive.

From the casperjs docs:

    "PhantomJS ships with a default viewport of 400x300, and CasperJS won’t
    override it by default."

http://casperjs.readthedocs.org/en/latest/modules/casper.html#viewportsize