### PR TITLE
Fix py3.4: hopefully the easiest and the correct way.

### DIFF
--- a/casper/tests.py
+++ b/casper/tests.py
@@ -64,14 +64,14 @@ class CasperTestCase(LiveServerTestCase):
         if settings.DEBUG:
             cmd.append('--verbose')
 
-        cmd.extend([('--%s=%s' % i) for i in kwargs.iteritems()])
+        cmd.extend([('--%s=%s' % i) for i in kwargs.items()])
         cmd.append(test_filename)
 
         node_env = os.environ.copy()
         node_env['PATH'] = \
             os.path.join(os.getcwd(), 'node_modules/.bin') + \
             ":" + node_env['PATH']
-        p = Popen(cmd, env=node_env, stdout=PIPE, stderr=PIPE,
+        p = Popen(cmd, env=node_env, stdout=PIPE, stderr=PIPE, universal_newlines=True,
             cwd=os.path.dirname(test_filename))  # flake8: noqa
         out, err = p.communicate()
         if p.returncode != 0:


### PR DESCRIPTION
While there are other branches with different approaches to the fix, this might be the correct one to get python-3.4 running.